### PR TITLE
Don't detect copies/renames in restore-mtime

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -324,7 +324,7 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd = 'whatchanged --no-renames --no-find-copies --pretty={}'.format('%ct' if commit_time else '%at')
         if merge:         cmd += ' -m'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'


### PR DESCRIPTION
The big benefit of this is in a [blobless clone], where it lets you avoid downloading all the blobs (which you shouldn't need just to know _whether_ a file changed). But it's probably a perf win always: it makes `git log` do a bit less work. (And it should always be at least as correct: for the purposes of mtime restoration, a move/copy should count as a modification -- your build tool should assume the file must be rebuilt in its new location.)

[blobless clone]: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

I tested this by:
- make a clone of a large repo (`git clone --filter=blob:none ...`)
- run `git restore-mtime` in the repo; after this change it takes ~10s

Before this change, in a blobless repo, it would loop for a very long time with periodic log lines indicating it was fetching more blobs:
```
remote: Enumerating objects: 2, done.
remote: Counting objects: 100% (1/1), done.
Receiving objects: 100% (2/2), 6.75 KiB | 2.25 MiB/s, done.
remote: Total 2 (delta 0), reused 0 (delta 0), pack-reused 1
```